### PR TITLE
修改回调时urldecode不彻底导致的签名验证失败的bug

### DIFF
--- a/src/Notify/AliNotify.php
+++ b/src/Notify/AliNotify.php
@@ -43,7 +43,7 @@ class AliNotify extends NotifyStrategy
      * @return array|boolean
      * @author helei
      */
-    protected function getNotifyData()
+    public function getNotifyData()
     {
         $data = empty($_POST) ? $_GET : $_POST;
         if (empty($data) || ! is_array($data)) {
@@ -62,7 +62,7 @@ class AliNotify extends NotifyStrategy
      * @return boolean
      * @author helei
      */
-    protected function checkNotifyData(array $data)
+    public function checkNotifyData(array $data)
     {
         // 检查签名
         $flag = $this->verifySign($data);

--- a/src/Notify/NotifyStrategy.php
+++ b/src/Notify/NotifyStrategy.php
@@ -85,7 +85,7 @@ abstract class NotifyStrategy
      * @return array|false
      * @author helei
      */
-    abstract protected function getNotifyData();
+    abstract public function getNotifyData();
 
     /**
      * 检查异步通知的数据是否合法
@@ -96,7 +96,7 @@ abstract class NotifyStrategy
      * @return boolean
      * @author helei
      */
-    abstract protected function checkNotifyData(array $data);
+    abstract public function checkNotifyData(array $data);
 
     /**
      * 向客户端返回必要的数据

--- a/src/Notify/WxNotify.php
+++ b/src/Notify/WxNotify.php
@@ -43,7 +43,7 @@ class WxNotify extends NotifyStrategy
      * @return array|bool
      * @author helei
      */
-    protected function getNotifyData()
+    public function getNotifyData()
     {
         // php://input 带来的内存压力更小
         $data = @file_get_contents('php://input');// 等同于微信提供的：$GLOBALS['HTTP_RAW_POST_DATA']
@@ -66,7 +66,7 @@ class WxNotify extends NotifyStrategy
      * @author helei
      * @return boolean
      */
-    protected function checkNotifyData(array $data)
+    public function checkNotifyData(array $data)
     {
         if ($data['return_code'] != 'SUCCESS' || $data['result_code'] != 'SUCCESS') {
             // $arrData['return_msg']  返回信息，如非空，为错误原因

--- a/src/Utils/ArrayUtil.php
+++ b/src/Utils/ArrayUtil.php
@@ -100,7 +100,7 @@ class ArrayUtil
                 continue;
             }
 
-            $arg.=$key."=".$val."&";
+            $arg.=$key."=".urldecode($val)."&";
         }
         //去掉最后一个&字符
         $arg = substr($arg, 0, count($arg) - 2);


### PR DESCRIPTION
1. 公开两个方法，使用者更灵活的使用组件
2. 修改回调时，urldecode不彻底导致的签名验证失败的bug