### PR TITLE
 招商银行一网通订单查询不限制要查询的订单的长度

### DIFF
--- a/src/Common/Cmb/Data/Query/ChargeQueryData.php
+++ b/src/Common/Cmb/Data/Query/ChargeQueryData.php
@@ -34,7 +34,7 @@ class ChargeQueryData extends CmbBaseData
 
         if ($bankSerialNo && mb_strlen($bankSerialNo) === 20) {
             $this->type = 'A';
-        } elseif ( $orderNo ) {
+        } elseif ( $orderNo && mb_strlen($bankSerialNo) <= 32) {
             $this->type = 'B';
         } else {
             throw new PayException('必须设置商户订单信息或者招商流水号');

--- a/src/Common/Cmb/Data/Query/ChargeQueryData.php
+++ b/src/Common/Cmb/Data/Query/ChargeQueryData.php
@@ -34,7 +34,7 @@ class ChargeQueryData extends CmbBaseData
 
         if ($bankSerialNo && mb_strlen($bankSerialNo) === 20) {
             $this->type = 'A';
-        } elseif (mb_strlen($orderNo) === 10) {
+        } elseif ( $orderNo ) {
             $this->type = 'B';
         } else {
             throw new PayException('必须设置商户订单信息或者招商流水号');

--- a/src/Common/Cmb/Data/Query/ChargeQueryData.php
+++ b/src/Common/Cmb/Data/Query/ChargeQueryData.php
@@ -34,7 +34,7 @@ class ChargeQueryData extends CmbBaseData
 
         if ($bankSerialNo && mb_strlen($bankSerialNo) === 20) {
             $this->type = 'A';
-        } elseif ( $orderNo && mb_strlen($bankSerialNo) <= 32) {
+        } elseif ( $orderNo && mb_strlen($bankSerialNo) <= 32 ) {
             $this->type = 'B';
         } else {
             throw new PayException('必须设置商户订单信息或者招商流水号');


### PR DESCRIPTION
 招商银行一网通订单查询的订单号长度限制是不超过32位。