### PR TITLE
在请求招行的接口时，在headers里面指定content-type为multipart/form-data

### DIFF
--- a/src/Common/Cmb/CmbBaseStrategy.php
+++ b/src/Common/Cmb/CmbBaseStrategy.php
@@ -98,6 +98,9 @@ abstract class CmbBaseStrategy implements BaseStrategy
         ]);
         // @note: 微信部分接口并不需要证书支持。这里为了统一，全部携带证书进行请求
         $options = [
+            'headers' => [
+                'content-type' => 'multipart/form-data',
+            ],
             'body' => $json,
             'http_errors' => false
         ];

--- a/src/Notify/CmbNotify.php
+++ b/src/Notify/CmbNotify.php
@@ -84,7 +84,7 @@ class CmbNotify extends NotifyStrategy
             $channel = 'other';
         }
 
-        if (!$this->config->returnRaw) {
+        if ($this->config->returnRaw) {
             $data['channel'] = $channel;
             return $data;
         } elseif ($noticeType === CmbConfig::NOTICE_PAY) {


### PR DESCRIPTION
在查询通过招行一网通内支付的订单的支付状态时，请求报错：错误提示：MSS9004.请求数据异常 [DJ120458]。后发现在调用接口时需要在headers内指定content-type