### PR TITLE
去除支付宝app支付只允许使用花呗限制

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "riverslei/payment",
+    "name": "dino.ma/payment",
     "type": "library",
     "description": "支付宝支付、微信支付、招商一网通支付php SDK。方便快速接入，最完整的开源支付 php sdk",
     "keywords": ["alipay", "weixin", "支付宝支付", "微信支付", "集成支付接口SDK", "招商一网通", "一网通"],

--- a/src/Gateways/Alipay/AppCharge.php
+++ b/src/Gateways/Alipay/AppCharge.php
@@ -73,7 +73,7 @@ class AppCharge extends AliBaseObject implements IGatewayRequest
             // 使用禁用列表
             //'enable_pay_channels' => '',
             'store_id'             => $requestParams['store_id'] ?? '',
-            'specified_channel'    => 'pcredit',
+//            'specified_channel'    => 'pcredit',
             'disable_pay_channels' => implode(self::$config->get('limit_pay', ''), ','),
             'ext_user_info'        => $requestParams['ext_user_info'] ?? '',
             'business_params'      => $requestParams['business_params'] ?? '',

--- a/src/Gateways/Alipay/WapCharge.php
+++ b/src/Gateways/Alipay/WapCharge.php
@@ -58,7 +58,7 @@ class WapCharge extends AliBaseObject implements IGatewayRequest
             //'enable_pay_channels' => '',
             'disable_pay_channels' => implode(self::$config->get('limit_pay', ''), ','),
             'store_id'             => $requestParams['store_id'] ?? '',
-            'specified_channel'    => $requestParams['specified_channel'] ?? '',
+//            'specified_channel'    => $requestParams['specified_channel'] ?? '',
             'business_params'      => $requestParams['business_params'] ?? '',
             'ext_user_info'        => $requestParams['ext_user_info'] ?? '',
         ];

--- a/src/Gateways/Wechat/AppCharge.php
+++ b/src/Gateways/Wechat/AppCharge.php
@@ -14,6 +14,8 @@ namespace Payment\Gateways\Wechat;
 use Payment\Contracts\IGatewayRequest;
 use Payment\Exceptions\GatewayException;
 use Payment\Payment;
+use Payment\Helpers\ArrayUtil;
+
 
 /**
  * @package Payment\Gateways\Wechat

--- a/src/Gateways/Wechat/AppCharge.php
+++ b/src/Gateways/Wechat/AppCharge.php
@@ -36,7 +36,27 @@ class AppCharge extends WechatBaseObject implements IGatewayRequest
     public function request(array $requestParams)
     {
         try {
-            return $this->requestWXApi(self::METHOD, $requestParams);
+            $info = $this->requestWXApi(self::METHOD, $requestParams);
+
+            if ($info['return_code'] == 'SUCCESS') {
+                $data = [
+                    'appid' =>  $info['appid'],
+                    'partnerid' =>  $info['mch_id'],
+                    'prepayid'  =>  $info['prepay_id'],
+                    'package'   =>  'Sign=WXPay',
+                    'noncestr'  =>  $info['nonce_str'],
+                    'timestamp' =>  time(),
+                ];
+
+                $data = ArrayUtil::paraFilter($data);
+                $data = ArrayUtil::arraySort($data);
+
+                $signStr        = ArrayUtil::createLinkstring($data);
+                $data['sign'] = $this->makeSign($signStr);
+                $info = $data;
+            }
+
+            return $info;
         } catch (GatewayException $e) {
             throw $e;
         }


### PR DESCRIPTION
1.去除支付宝app支付只允许使用花呗限制
2.增加微信app支付 返回给客户端的app信息用于唤醒app