### PR TITLE
implode() 等代码规范

### DIFF
--- a/src/Gateways/Alipay/AppCharge.php
+++ b/src/Gateways/Alipay/AppCharge.php
@@ -74,7 +74,7 @@ class AppCharge extends AliBaseObject implements IGatewayRequest
             //'enable_pay_channels' => '',
             'store_id'             => $requestParams['store_id'] ?? '',
             'specified_channel'    => 'pcredit',
-            'disable_pay_channels' => implode(self::$config->get('limit_pay', ''), ','),
+            'disable_pay_channels' => implode(',', self::$config->get('limit_pay', '')),
             'ext_user_info'        => $requestParams['ext_user_info'] ?? '',
             'business_params'      => $requestParams['business_params'] ?? '',
         ];

--- a/src/Gateways/Alipay/Notify.php
+++ b/src/Gateways/Alipay/Notify.php
@@ -35,7 +35,7 @@ class Notify extends AliBaseObject
             throw new GatewayException('the notify data is empty', Payment::NOTIFY_DATA_EMPTY);
         }
 
-        if (isset($resArr['notify_type']) && isset($resArr['trade_status'])) {
+        if (isset($resArr['notify_type'], $resArr['trade_status'])) {
             $notifyWay = 'async'; // 异步
         } else {
             $notifyWay = 'sync'; // 同步

--- a/src/Gateways/Alipay/QrCharge.php
+++ b/src/Gateways/Alipay/QrCharge.php
@@ -51,7 +51,7 @@ class QrCharge extends AliBaseObject implements IGatewayRequest
             'body'                 => $requestParams['body'] ?? '',
             'operator_id'          => $requestParams['operator_id'] ?? '',
             'store_id'             => $requestParams['store_id'] ?? '',
-            'disable_pay_channels' => implode(self::$config->get('limit_pay', ''), ','),
+            'disable_pay_channels' => implode(',', self::$config->get('limit_pay', '')),
             // 使用禁用列表
             //'enable_pay_channels' => '',
             'terminal_id'             => $requestParams['terminal_id'] ?? '',

--- a/src/Gateways/Alipay/WapCharge.php
+++ b/src/Gateways/Alipay/WapCharge.php
@@ -56,7 +56,7 @@ class WapCharge extends AliBaseObject implements IGatewayRequest
             'extend_params'   => $requestParams['extend_params'] ?? '',
             // 使用禁用列表
             //'enable_pay_channels' => '',
-            'disable_pay_channels' => implode(self::$config->get('limit_pay', ''), ','),
+            'disable_pay_channels' => implode(',', self::$config->get('limit_pay', '')),
             'store_id'             => $requestParams['store_id'] ?? '',
             'specified_channel'    => $requestParams['specified_channel'] ?? '',
             'business_params'      => $requestParams['business_params'] ?? '',

--- a/src/Gateways/Alipay/WebCharge.php
+++ b/src/Gateways/Alipay/WebCharge.php
@@ -76,7 +76,7 @@ class WebCharge extends AliBaseObject implements IGatewayRequest
             // 使用禁用列表
             //'enable_pay_channels' => '',
             'store_id'              => $requestParams['store_id'] ?? '',
-            'disable_pay_channels'  => implode(self::$config->get('limit_pay', ''), ','),
+            'disable_pay_channels'  => implode(',', self::$config->get('limit_pay', '')),
             'qr_pay_mode'           => $requestParams['qr_pay_mode'] ?? '2',
             'qrcode_width'          => $requestParams['qrcode_width'] ?? '',
             'settle_info'           => $requestParams['settle_info'] ?? '',

--- a/src/Gateways/CMBank/AppCharge.php
+++ b/src/Gateways/CMBank/AppCharge.php
@@ -43,7 +43,7 @@ class AppCharge extends CMBaseObject implements IGatewayRequest
     {
         $nowTime    = time();
         $timeExpire = $requestParams['time_expire'] ?? 0;
-        $timeExpire = $timeExpire - $nowTime;
+        $timeExpire -= $nowTime;
         if ($timeExpire < 3) {
             $timeExpire = 30; // 如果设置不合法，默认改为30
         }

--- a/src/Gateways/CMBank/LiteCharge.php
+++ b/src/Gateways/CMBank/LiteCharge.php
@@ -54,7 +54,7 @@ class LiteCharge extends CMBaseObject implements IGatewayRequest
     {
         $nowTime    = time();
         $timeExpire = $requestParams['time_expire'] ?? 0;
-        $timeExpire = $timeExpire - $nowTime;
+        $timeExpire -= $nowTime;
         if ($timeExpire < 3) {
             $timeExpire = 30; // 如果设置不合法，默认改为30
         }

--- a/src/Gateways/CMBank/QrCharge.php
+++ b/src/Gateways/CMBank/QrCharge.php
@@ -54,7 +54,7 @@ class QrCharge extends CMBaseObject implements IGatewayRequest
     {
         $nowTime    = time();
         $timeExpire = $requestParams['time_expire'] ?? 0;
-        $timeExpire = $timeExpire - $nowTime;
+        $timeExpire -= $nowTime;
         if ($timeExpire < 3) {
             $timeExpire = 30; // 如果设置不合法，默认改为30
         }

--- a/src/Gateways/CMBank/WapCharge.php
+++ b/src/Gateways/CMBank/WapCharge.php
@@ -54,7 +54,7 @@ class WapCharge extends CMBaseObject implements IGatewayRequest
     {
         $nowTime    = time();
         $timeExpire = $requestParams['time_expire'] ?? 0;
-        $timeExpire = $timeExpire - $nowTime;
+        $timeExpire -= $nowTime;
         if ($timeExpire < 3) {
             $timeExpire = 30; // 如果设置不合法，默认改为30
         }

--- a/src/Gateways/CMBank/WebCharge.php
+++ b/src/Gateways/CMBank/WebCharge.php
@@ -54,7 +54,7 @@ class WebCharge extends CMBaseObject implements IGatewayRequest
     {
         $nowTime    = time();
         $timeExpire = $requestParams['time_expire'] ?? 0;
-        $timeExpire = $timeExpire - $nowTime;
+        $timeExpire -= $nowTime;
         if ($timeExpire < 3) {
             $timeExpire = 30; // 如果设置不合法，默认改为30
         }

--- a/src/Helpers/Rsa2Encrypt.php
+++ b/src/Helpers/Rsa2Encrypt.php
@@ -52,7 +52,7 @@ class Rsa2Encrypt
             return '';
         }
 
-        $res = openssl_get_privatekey($this->key);
+        $res = openssl_pkey_get_private($this->key);
         if (empty($res)) {
             throw new \Exception('您使用的私钥格式错误，请检查RSA私钥配置');
         }
@@ -78,7 +78,7 @@ class Rsa2Encrypt
             return '';
         }
 
-        $res = openssl_get_privatekey($this->key);
+        $res = openssl_pkey_get_private($this->key);
         if (empty($res)) {
             throw new \Exception('您使用的私钥格式错误，请检查RSA私钥配置');
         }

--- a/src/Helpers/RsaEncrypt.php
+++ b/src/Helpers/RsaEncrypt.php
@@ -52,7 +52,7 @@ class RsaEncrypt
             return '';
         }
 
-        $res = openssl_get_privatekey($this->key);
+        $res = openssl_pkey_get_private($this->key);
         if (empty($res)) {
             throw new \Exception('您使用的私钥格式错误，请检查RSA私钥配置');
         }
@@ -78,7 +78,7 @@ class RsaEncrypt
             return '';
         }
 
-        $res = openssl_get_privatekey($this->key);
+        $res = openssl_pkey_get_private($this->key);
         if (empty($res)) {
             throw new \Exception('您使用的私钥格式错误，请检查RSA私钥配置');
         }

--- a/src/Helpers/StrUtil.php
+++ b/src/Helpers/StrUtil.php
@@ -32,7 +32,7 @@ class StrUtil
         $chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
         $str   = '';
         for ($i = 0; $i < $length; $i++) {
-            $str .= substr($chars, mt_rand(0, strlen($chars) - 1), 1);
+            $str .= $chars[mt_rand(0, strlen($chars) - 1)];
         }
         return $str;
     }


### PR DESCRIPTION
修复  #221  问题1
- `implode()` 依据https://www.php.net/manual/en/function.implode
 PHP 7.4 版本后，不再支持glue在后的写法，统一为glue在前，array再后；
- `isset()` 依据 https://www.php.net/manual/en/function.isset.php
可以使用`isset($a, $b)`来搞2值都要set；
- `-=` 的用法，纯粹的简化写法；
- `openssl_pkey_get_private()` 依据https://www.php.net/manual/zh/function.openssl-get-privatekey.php
`openssl_get_privatekey` 是`openssl_pkey_get_private()`的别名；
